### PR TITLE
[Feat/#1] add: user, sos 간 JPA 연관관계 mapping

### DIFF
--- a/src/main/java/PhishingUniv/Phinocchio/domain/Sos/controller/SosController.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Sos/controller/SosController.java
@@ -3,6 +3,7 @@ package PhishingUniv.Phinocchio.domain.Sos.controller;
 import PhishingUniv.Phinocchio.domain.Sos.dto.SosDeleteDto;
 import PhishingUniv.Phinocchio.domain.Sos.dto.SosDto;
 import PhishingUniv.Phinocchio.domain.Sos.dto.SosUpdateDto;
+import PhishingUniv.Phinocchio.domain.Sos.entity.SosEntity;
 import PhishingUniv.Phinocchio.domain.Sos.service.SosService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/sos")
@@ -21,25 +24,25 @@ public class SosController {
 
     @GetMapping("/list")
     @Operation(summary = "SOS 리스트를 조회하는 컨트롤러", description = "SOS 리스트를 조회하는 컨트롤러입니다.")
-    public ResponseEntity list() {
+    public List<SosEntity> list() {
         return sosService.sosList();
     }
 
     @PostMapping("/add")
     @Operation(summary = "SOS를 추가하는 컨트롤러", description = "SOS를 추가하는 컨트롤러입니다.")
-    public ResponseEntity add(@RequestBody SosDto sosDto) {
+    public ResponseEntity<?> add(@RequestBody SosDto sosDto) {
         return sosService.addSos(sosDto);
     }
 
     @PostMapping("/update")
     @Operation(summary = "SOS를 수정하는 컨트롤러", description = "SOS를 수정하는 컨트롤러입니다.")
-    public ResponseEntity update(@RequestBody SosUpdateDto sosUpdateDto) {
+    public ResponseEntity<?> update(@RequestBody SosUpdateDto sosUpdateDto) {
         return sosService.updateSos(sosUpdateDto);
     }
 
     @PostMapping("/delete")
     @Operation(summary = "SOS를 삭제하는 컨트롤러", description = "SOS를 삭제하는 컨트롤러입니다.")
-    public ResponseEntity delete(@RequestBody SosDeleteDto sosDeleteDto) {
+    public ResponseEntity<?> delete(@RequestBody SosDeleteDto sosDeleteDto) {
         return sosService.deleteSos(sosDeleteDto);
     }
 

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Sos/entity/SosEntity.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Sos/entity/SosEntity.java
@@ -1,5 +1,7 @@
 package PhishingUniv.Phinocchio.domain.Sos.entity;
 
+import PhishingUniv.Phinocchio.domain.User.entity.UserEntity;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,8 +18,10 @@ public class SosEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long sosId;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id")
+    @JsonIgnoreProperties({"sosList"})
+    private UserEntity user;
 
     @Column(name = "phone_number", nullable = false, length = 20)
     private String phoneNumber;

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Sos/service/SosService.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Sos/service/SosService.java
@@ -38,27 +38,26 @@ public class SosService {
         return modelMapper.map(sosUpdateDto, SosEntity.class);
     }
 
-    public ResponseEntity sosList() throws LoginAppException{
+    public List<SosEntity> sosList() throws LoginAppException{
         String id = SecurityContextHolder.getContext().getAuthentication().getName();
         UserEntity userEntity = userRepository.findById(id)
                 .orElseThrow(() -> new LoginAppException(LoginErrorCode.USERNAME_NOT_FOUND));
-        Long userId = userEntity.getUserId();
+        List<SosEntity> sosList = userEntity.getSosList();
 
-        return ResponseEntity.ok(sosRepository.findByUserId(userId));
+        return sosList;
     }
 
-    public ResponseEntity addSos(SosDto sosDto) throws LoginAppException{
+    public ResponseEntity<?> addSos(SosDto sosDto) throws LoginAppException{
         SosEntity sosEntity = convertToEntity(sosDto);
 
         String id = SecurityContextHolder.getContext().getAuthentication().getName();
         UserEntity userEntity = userRepository.findById(id)
                 .orElseThrow(() -> new LoginAppException(LoginErrorCode.USERNAME_NOT_FOUND));
-        Long userId = userEntity.getUserId();
 
-        sosEntity.setUserId(userId);
+        sosEntity.setUser(userEntity);
 
         sosRepository.save(sosEntity);
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     public ResponseEntity updateSos(SosUpdateDto sosUpdateDto) throws SosAppException, LoginAppException{
@@ -70,12 +69,11 @@ public class SosService {
         String id = SecurityContextHolder.getContext().getAuthentication().getName();
         UserEntity userEntity = userRepository.findById(id)
                 .orElseThrow(() -> new LoginAppException(LoginErrorCode.USERNAME_NOT_FOUND));
-        Long userId = userEntity.getUserId();
 
-        sosEntity.setUserId(userId);
+        sosEntity.setUser(userEntity);
         sosRepository.save(sosEntity);
 
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.OK);
 
     }
 
@@ -85,7 +83,7 @@ public class SosService {
 
         sosRepository.delete(sosEntity);
 
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.OK);
 
     }
 

--- a/src/main/java/PhishingUniv/Phinocchio/domain/User/entity/UserEntity.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/User/entity/UserEntity.java
@@ -5,7 +5,11 @@ package PhishingUniv.Phinocchio.domain.User.entity;
 import PhishingUniv.Phinocchio.domain.Login.dto.SignupRequestDto;
 import javax.persistence.*;
 
+import PhishingUniv.Phinocchio.domain.Sos.entity.SosEntity;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Entity
@@ -36,6 +40,9 @@ public class UserEntity extends Timestamp{
 
     @Column(name = "fcm_token", nullable = false)
     private String fcmToken;
+
+    @OneToMany(mappedBy = "user")
+    List<SosEntity> sosList = new ArrayList<>();
 
     /*@Column(name = "registration_date", nullable = false)
     @Temporal(TemporalType.TIMESTAMP)


### PR DESCRIPTION
## sos : user = N : 1 (양방향)

### 🔗 sos와 user의 연관관계

사용자가 긴급연락처를 추가, 수정, 삭제, 조회를 할 수 있다.

### ✈️ 구현 방향

### 긴급연락처 조회

- 프론트 서버에서 사용자의 토큰 정보만 가지고 조회 요청
- User entity가 가지고 있는 sos List 정보만 추출하여 반환

### 긴급연락처 수정 및 삭제

- 프론트 서버에서 사용자의 토큰 정보와 sos_id으로 수정 및 삭제 요청
- user_id와 sos_id로 Sos table에서 조회 후 수정 및 삭제 실행
- User entity의 sos List는 자동으로 업데이트

### 양방향으로 구현 시 장점

> 필요한 정보를 한번의 쿼리로 가져올 수 있다. 효율성 ⬆️
> 
> 
> userEntity에서 역참조를 통해 해당 사용자와 연관된 sosEntity 목록에 쉽게 접근 가능
>