### PR TITLE
[Feat/#2] add: user, doubt 간 JPA 연간관계 mapping

### DIFF
--- a/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/entity/DoubtEntity.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/entity/DoubtEntity.java
@@ -1,6 +1,7 @@
 package PhishingUniv.Phinocchio.domain.Doubt.entity;
 
 import PhishingUniv.Phinocchio.domain.User.entity.UserEntity;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -25,6 +26,7 @@ public class DoubtEntity extends Timestamp {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @JsonIgnoreProperties({"doubtList"})
     private UserEntity user;
 
     @Column(name = "title", nullable = false)

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/entity/DoubtEntity.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/entity/DoubtEntity.java
@@ -25,7 +25,7 @@ public class DoubtEntity extends Timestamp {
     private int level;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id")
     @JsonIgnoreProperties({"doubtList"})
     private UserEntity user;
 

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/entity/DoubtEntity.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/entity/DoubtEntity.java
@@ -1,5 +1,6 @@
 package PhishingUniv.Phinocchio.domain.Doubt.entity;
 
+import PhishingUniv.Phinocchio.domain.User.entity.UserEntity;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -22,8 +23,9 @@ public class DoubtEntity extends Timestamp {
     @Column(name = "level", nullable = false)
     private int level;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private UserEntity user;
 
     @Column(name = "title", nullable = false)
     private String title;

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/service/DoubtService.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/service/DoubtService.java
@@ -99,10 +99,7 @@ public class DoubtService {
         UserEntity userEntity = userRepository.findById(ID).orElseThrow(
                 ()->new InvalidJwtException(LoginErrorCode.JWT_USER_NOT_FOUND));
 
-        Long userId = userEntity.getUserId();
-        List<DoubtEntity> doubtEntities = doubtRepository.findDoubtEntitiesByUserId(userId);
-
-        return doubtEntities;
+        return userEntity.getDoubtList();
 
     }
     private void addDoubt(DoubtRequestDto doubtRequestDto, String text, int level) throws InvalidJwtException, DoubtAppException, VoiceAppException {
@@ -125,7 +122,7 @@ public class DoubtService {
         DoubtEntity doubtEntity = new DoubtEntity();
         doubtEntity.setPhoneNumber(doubtRequestDto.getPhoneNumber());
         doubtEntity.setLevel(level);
-        doubtEntity.setUserId(userId);
+        doubtEntity.setUser(userEntity);
         doubtEntity.setTitle(getCurrentTime());
         doubtEntity.setVoice_id(savedVoiceEntity.getVoiceId());
         DoubtEntity savedDoubtEntity = doubtRepository.save(doubtEntity);

--- a/src/main/java/PhishingUniv/Phinocchio/domain/User/entity/UserEntity.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/User/entity/UserEntity.java
@@ -2,7 +2,9 @@ package PhishingUniv.Phinocchio.domain.User.entity;
 
 
 
+import PhishingUniv.Phinocchio.domain.Doubt.entity.DoubtEntity;
 import PhishingUniv.Phinocchio.domain.Login.dto.SignupRequestDto;
+import java.util.List;
 import javax.persistence.*;
 
 import lombok.*;
@@ -36,6 +38,9 @@ public class UserEntity extends Timestamp{
 
     @Column(name = "fcm_token", nullable = false)
     private String fcmToken;
+
+    @OneToMany(mappedBy = "user")
+    private List<DoubtEntity> doubtList;
 
     /*@Column(name = "registration_date", nullable = false)
     @Temporal(TemporalType.TIMESTAMP)


### PR DESCRIPTION
## doubt : user = N : 1 (양방향)

### 🔗 doubt와 user의 연관관계

1. 보이스피싱을 탐지한 경우, 해당 사용자에게 제공되는 보이스피싱 의심 내역을 추가한다.
2. 사용자가 보이스피싱 신고를 하는 경우, 보이스피싱 의심 내역을 불러와 사용자에게 제공한다.

### ✈️ 구현방향

### 실제 연관관계: 일대다 단방향

user에서 doubt list를 조회한다.

즉, 1에서 N의 데이터에 접근한다.

### 구현한 연관관계: 다대일 양방향 ✅

일대다 단방향의 경우, sql문의 중복 사용으로 인해 권장되지 않는다.

**일대다 단방향 혹은 일대다 양방향**은 **다대일 단방향 혹은 다대일 양방향**으로 구현될 것을 권장한다.

따라서, 다대일 양방향으로 구현하였다.