### PR TITLE
[Feat/#5] add: doubt, report 간 JPA 연간관계 mapping

### DIFF
--- a/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/entity/DoubtEntity.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Doubt/entity/DoubtEntity.java
@@ -1,5 +1,6 @@
 package PhishingUniv.Phinocchio.domain.Doubt.entity;
 
+import PhishingUniv.Phinocchio.domain.Report.entity.ReportEntity;
 import PhishingUniv.Phinocchio.domain.User.entity.UserEntity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
@@ -35,6 +36,8 @@ public class DoubtEntity extends Timestamp {
     @Column(name = "voiceId", nullable = false)
     private Long voice_id;
 
-    @Column(name = "reportId")
-    private Long report_id;
+
+    @OneToOne
+    @JoinColumn(name="report_id")
+    private ReportEntity report;
 }

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Report/service/ReportService.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Report/service/ReportService.java
@@ -28,7 +28,7 @@ public class ReportService {
     private final DoubtRepository doubtRepository;
     private final ReportRepository reportRepository;
 
-    //userId가져오기 위해서 임시로 만들어둔 것, 캐싱으로 나중에 수정해야하는 부분
+    //userId 가져오기 위해서 임시로 만들어둔 것, 캐싱으로 나중에 수정해야하는 부분
     private final UserRepository userRepository;
     public ReportEntity addReport(ReportDto reportDto) {
         String ID = SecurityContextHolder.getContext().getAuthentication().getName();
@@ -40,15 +40,12 @@ public class ReportService {
         ReportEntity reportEntity = new ReportEntity(reportDto.getType(), reportDto.getTitle(), reportDto.getContent()
                                                 ,reportDto.getPhoneNumber(),userId,reportDto.getVoiceId());
 
-        Long reportId = reportRepository.save(reportEntity).getReportId();
+        reportRepository.save(reportEntity);
 
         DoubtEntity doubtEntity = doubtRepository.findById(reportDto.getDoubtId()).orElseThrow(() -> new DoubtAppException(
                 DoubtErrorCode.DOUBT_NOT_FOUND));
-        doubtEntity.setReport_id(reportId);
+        doubtEntity.setReport(reportEntity);
         doubtRepository.save(doubtEntity);
-        //doubt에 있는 report_id update해주어야함
-        //doubtId
-
 
         return reportEntity;
     }
@@ -67,10 +64,6 @@ public class ReportService {
                 .content(reportDto.getContent())
                 .phoneNumber(reportDto.getPhoneNumber())
                 .userId(userId).build();
-
-
-        //doubt에 있는 report_id update해주어야함
-        //doubtId
 
         return reportRepository.save(reportEntity);
     }


### PR DESCRIPTION
## doubt : report = 1 : 1 (단방향)

### 🔗 doubt와 report의 연관관계

- 사용자가 의심내역에 대해서 신고를 할 수 있다.
    - 피노키오에서 보이스피싱을 탐지하였을 경우, 해당 대화 내용이 의심내역 리스트에 추가된다.
    - 사용자는 의심내역 리스트에서 신고를 할 수 있다.

### ✈️ 구현 방향

### 의심내역에 대해서 신고하는 기능

- Report 데이터 저장 시, Doubt 데이터에 Report Entity 저장
