### PR TITLE
[Feat/#9] add: report, user 간 JPA 연간관계 mapping

### DIFF
--- a/src/main/java/PhishingUniv/Phinocchio/domain/Report/entity/ReportEntity.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Report/entity/ReportEntity.java
@@ -1,5 +1,8 @@
 package PhishingUniv.Phinocchio.domain.Report.entity;
 
+import PhishingUniv.Phinocchio.domain.User.entity.UserEntity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,19 +35,21 @@ public class ReportEntity extends Timestamp {
     @Column(name = "phone_number", nullable = false, length = 20)
     private String phoneNumber;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id")
+    @JsonIgnoreProperties({"sosList"})
+    private UserEntity user;
 
     @Column(name = "voice_id")
     private Long voiceId;
 
-    public ReportEntity(ReportType reportType, String title, String content, String phoneNumber, Long userId, Long voiceId)
+    public ReportEntity(ReportType reportType, String title, String content, String phoneNumber, UserEntity user, Long voiceId)
     {
         this.title = title;
         this.type = reportType;
         this.content = content;
         this.phoneNumber = phoneNumber;
-        this.userId = userId;
+        this.user = user;
         this.voiceId = voiceId;
     }
 }

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Report/repository/ReportRepository.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Report/repository/ReportRepository.java
@@ -1,14 +1,15 @@
 package PhishingUniv.Phinocchio.domain.Report.repository;
 
 import PhishingUniv.Phinocchio.domain.Report.entity.ReportEntity;
+import PhishingUniv.Phinocchio.domain.User.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ReportRepository extends JpaRepository<ReportEntity, Long> {
-    Optional<ReportEntity> findByUserId(Long id);
-    List<ReportEntity> findReportEntitiesByUserId(Long userid);
+    Optional<ReportEntity> findByUser(UserEntity user);
+    List<ReportEntity> findReportEntitiesByUser(UserEntity user);
 
 
     List<ReportEntity> findReportEntitiesByPhoneNumber(String phoneNumber);

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Report/service/ReportService.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Report/service/ReportService.java
@@ -4,7 +4,6 @@ package PhishingUniv.Phinocchio.domain.Report.service;
 import PhishingUniv.Phinocchio.domain.Doubt.entity.DoubtEntity;
 import PhishingUniv.Phinocchio.domain.Doubt.repository.DoubtRepository;
 import PhishingUniv.Phinocchio.domain.Login.repository.UserRepository;
-import PhishingUniv.Phinocchio.domain.Login.security.UserDetailsImpl;
 import PhishingUniv.Phinocchio.domain.Report.dto.ReportDto;
 import PhishingUniv.Phinocchio.domain.Report.dto.ReportWithoutDoubtDto;
 import PhishingUniv.Phinocchio.domain.Report.entity.ReportEntity;
@@ -15,11 +14,9 @@ import PhishingUniv.Phinocchio.exception.Doubt.DoubtErrorCode;
 import PhishingUniv.Phinocchio.exception.Login.InvalidJwtException;
 import PhishingUniv.Phinocchio.exception.Login.LoginErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -35,10 +32,9 @@ public class ReportService {
         UserEntity userEntity =userRepository.findById(ID).orElseThrow(
                 ()->new InvalidJwtException(LoginErrorCode.JWT_USER_NOT_FOUND));
 
-        Long userId = userEntity.getUserId();
 
         ReportEntity reportEntity = new ReportEntity(reportDto.getType(), reportDto.getTitle(), reportDto.getContent()
-                                                ,reportDto.getPhoneNumber(),userId,reportDto.getVoiceId());
+                                                ,reportDto.getPhoneNumber(),userEntity,reportDto.getVoiceId());
 
         Long reportId = reportRepository.save(reportEntity).getReportId();
 
@@ -59,14 +55,12 @@ public class ReportService {
         UserEntity userEntity =userRepository.findById(ID).orElseThrow(
                 ()->new InvalidJwtException(LoginErrorCode.JWT_USER_NOT_FOUND));
 
-        Long userId = userEntity.getUserId();
-
         ReportEntity reportEntity = ReportEntity.builder()
                 .type(reportDto.getType())
                 .title(reportDto.getTitle())
                 .content(reportDto.getContent())
                 .phoneNumber(reportDto.getPhoneNumber())
-                .userId(userId).build();
+                .user(userEntity).build();
 
 
         //doubt에 있는 report_id update해주어야함
@@ -81,8 +75,7 @@ public class ReportService {
         UserEntity userEntity =userRepository.findById(ID).orElseThrow(
                 ()->new InvalidJwtException(LoginErrorCode.JWT_USER_NOT_FOUND));
 
-        Long userId = userEntity.getUserId();
-        List<ReportEntity> reportEntities = reportRepository.findReportEntitiesByUserId(userId);
+        List<ReportEntity> reportEntities = reportRepository.findReportEntitiesByUser(userEntity);
 
         return reportEntities;
 


### PR DESCRIPTION
## report : user = N : 1 (단방향)
### 🔗 report와 user의 연관관계
- 사용자가 보이스피싱으로 의심되는 번호 신고 기능
- 사용자 본인이 신고한 내역 조회 기능
- 사용자가 특정 번호의 신고 횟수를 조회 기능

### ✈️ 구현 방향
우리 서비스를 사용하는 사용자의 경우
보이스 피싱을 방지하기 위한 목적을 가진 사용자가 많을 것으로 예상된다.

따라서 내가 신고한 내역보단, 남들이 신고했던 전화번호의 신고 내역을 조회하는 기능을 더 사용할 것이라는 판단하에 단방향으로 결정