### PR TITLE
[Feat/#11] add: report, voice 간 JPA 연간관계 mapping

### DIFF
--- a/src/main/java/PhishingUniv/Phinocchio/domain/Report/entity/ReportEntity.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Report/entity/ReportEntity.java
@@ -1,7 +1,7 @@
 package PhishingUniv.Phinocchio.domain.Report.entity;
 
 import PhishingUniv.Phinocchio.domain.User.entity.UserEntity;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import PhishingUniv.Phinocchio.domain.Voice.entity.VoiceEntity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -40,16 +40,17 @@ public class ReportEntity extends Timestamp {
     @JsonIgnoreProperties({"sosList"})
     private UserEntity user;
 
-    @Column(name = "voice_id")
-    private Long voiceId;
+    @OneToOne
+    @JoinColumn(name="voice_id")
+    private VoiceEntity voice;
 
-    public ReportEntity(ReportType reportType, String title, String content, String phoneNumber, UserEntity user, Long voiceId)
+    public ReportEntity(ReportType reportType, String title, String content, String phoneNumber, UserEntity user, VoiceEntity voice)
     {
         this.title = title;
         this.type = reportType;
         this.content = content;
         this.phoneNumber = phoneNumber;
         this.user = user;
-        this.voiceId = voiceId;
+        this.voice = voice;
     }
 }

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Report/service/ReportService.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Report/service/ReportService.java
@@ -9,6 +9,8 @@ import PhishingUniv.Phinocchio.domain.Report.dto.ReportWithoutDoubtDto;
 import PhishingUniv.Phinocchio.domain.Report.entity.ReportEntity;
 import PhishingUniv.Phinocchio.domain.Report.repository.ReportRepository;
 import PhishingUniv.Phinocchio.domain.User.entity.UserEntity;
+import PhishingUniv.Phinocchio.domain.Voice.entity.VoiceEntity;
+import PhishingUniv.Phinocchio.domain.Voice.repository.VoiceRepository;
 import PhishingUniv.Phinocchio.exception.Doubt.DoubtAppException;
 import PhishingUniv.Phinocchio.exception.Doubt.DoubtErrorCode;
 import PhishingUniv.Phinocchio.exception.Login.InvalidJwtException;
@@ -18,12 +20,14 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 public class ReportService {
     private final DoubtRepository doubtRepository;
     private final ReportRepository reportRepository;
+    private final VoiceRepository voiceRepository;
 
     //userId 가져오기 위해서 임시로 만들어둔 것, 캐싱으로 나중에 수정해야하는 부분
     private final UserRepository userRepository;
@@ -32,9 +36,11 @@ public class ReportService {
         UserEntity userEntity =userRepository.findById(ID).orElseThrow(
                 ()->new InvalidJwtException(LoginErrorCode.JWT_USER_NOT_FOUND));
 
+        Optional<VoiceEntity> optionalVoiceEntity = voiceRepository.findByVoiceId(reportDto.getVoiceId());
+        VoiceEntity voice = optionalVoiceEntity.orElseThrow(() -> new RuntimeException("해당 voice table이 존재하지 않습니다."));
 
         ReportEntity reportEntity = new ReportEntity(reportDto.getType(), reportDto.getTitle(), reportDto.getContent()
-                                                ,reportDto.getPhoneNumber(),userEntity,reportDto.getVoiceId());
+                                                ,reportDto.getPhoneNumber(),userEntity, voice);
 
         reportRepository.save(reportEntity);
 

--- a/src/main/java/PhishingUniv/Phinocchio/domain/Voice/repository/VoiceRepository.java
+++ b/src/main/java/PhishingUniv/Phinocchio/domain/Voice/repository/VoiceRepository.java
@@ -3,8 +3,12 @@ package PhishingUniv.Phinocchio.domain.Voice.repository;
 import PhishingUniv.Phinocchio.domain.Voice.entity.VoiceEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface VoiceRepository extends JpaRepository<VoiceEntity, Long> {
 
     VoiceEntity save(VoiceEntity voiceEntity);
+
+    Optional<VoiceEntity> findByVoiceId(Long voiceId);
 
 }


### PR DESCRIPTION
## report : voice = 1 : 1 (단방향)

### 🔗 report와 voice의 연관관계
- 보이스피싱으로 의심되는 번호 신고시
해당 번호의 의심내역 정보(voice 포함)가 그대로 저장된다.

### ✈️ 구현 방향
신고내역 내에 Voice Entity가 함께 저장된다.